### PR TITLE
1.20.1 Broad compatibility patch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Too Many Keybinds
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.8.0b
+mod_version=0.8.1b
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -2,6 +2,8 @@ package io.github.jkaano.toomanykeybinds;
 
 import io.github.jkaano.toomanykeybinds.client.KeyHandler;
 import io.github.jkaano.toomanykeybinds.client.TMKPageHandler;
+import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
+import io.github.jkaano.toomanykeybinds.client.compatibility.RobotCompatibilityChecker;
 import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import io.github.jkaano.toomanykeybinds.client.gui.ButtonIdentity;
 import net.minecraftforge.fml.ModLoadingContext;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -2,11 +2,9 @@ package io.github.jkaano.toomanykeybinds;
 
 import io.github.jkaano.toomanykeybinds.client.KeyHandler;
 import io.github.jkaano.toomanykeybinds.client.TMKPageHandler;
-import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
 import io.github.jkaano.toomanykeybinds.client.compatibility.RobotCompatibilityChecker;
 import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import io.github.jkaano.toomanykeybinds.client.gui.ButtonIdentity;
-import io.github.jkaano.toomanykeybinds.client.handler.RobotHandler;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -18,14 +16,6 @@ import java.util.List;
 public class TooManyKeybinds {
     public static final String MODID = "toomanykeybinds";
 
-    public static RobotCompatibilityChecker robotCompatibilityChecker;
-
-    public TooManyKeybinds(){
-        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
-        //Create compatibility checking object
-        robotCompatibilityChecker = new RobotCompatibilityChecker();
-    }
-
     private static int page = 0;
     private static int pageSelect = 0;
 
@@ -35,6 +25,14 @@ public class TooManyKeybinds {
     public static boolean searching = false;
 
     public static List<ButtonIdentity> keyQueue = new ArrayList<>();
+
+    public static RobotCompatibilityChecker robotCompatibilityChecker;
+
+    public TooManyKeybinds(){
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
+        //Create compatibility checking object
+        robotCompatibilityChecker = new RobotCompatibilityChecker();
+    }
 
     public static void setPage(int page) {
         TooManyKeybinds.page = page;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -54,4 +54,8 @@ public class TooManyKeybinds {
         return pageSelect;
     }
 
+    public static RobotCompatibilityChecker getRobotCompatibilityChecker(){
+        return robotCompatibilityChecker;
+    }
+
 }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -6,6 +6,7 @@ import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibi
 import io.github.jkaano.toomanykeybinds.client.compatibility.RobotCompatibilityChecker;
 import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import io.github.jkaano.toomanykeybinds.client.gui.ButtonIdentity;
+import io.github.jkaano.toomanykeybinds.client.handler.RobotHandler;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -23,9 +24,6 @@ public class TooManyKeybinds {
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
         //Create compatibility checking object
         robotCompatibilityChecker = new RobotCompatibilityChecker();
-
-        //Set compatibilities
-        EssentialsCompatibility.setEssentials();
     }
 
     private static int page = 0;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -17,6 +17,8 @@ import java.util.List;
 public class TooManyKeybinds {
     public static final String MODID = "toomanykeybinds";
 
+    public static RobotCompatibilityChecker robotCompatibilityChecker;
+
     public TooManyKeybinds(){
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
     }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/TooManyKeybinds.java
@@ -21,6 +21,11 @@ public class TooManyKeybinds {
 
     public TooManyKeybinds(){
         ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.SPEC);
+        //Create compatibility checking object
+        robotCompatibilityChecker = new RobotCompatibilityChecker();
+
+        //Set compatibilities
+        EssentialsCompatibility.setEssentials();
     }
 
     private static int page = 0;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -93,7 +93,6 @@ public class TMKPageHandler {
         }
         return t;
     }
-
     //Getters
     public List<TMKPage> getPages(){
         return pages;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -1,6 +1,7 @@
 package io.github.jkaano.toomanykeybinds.client;
 
 import com.google.common.collect.Lists;
+import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import io.github.jkaano.toomanykeybinds.client.gui.PageButtonIdentity;
 import io.github.jkaano.toomanykeybinds.client.gui.TMKPage;
 import io.github.jkaano.toomanykeybinds.client.screen.TMKScreen;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -58,6 +58,7 @@ public class TMKPageHandler {
         screen.update();
     }
 
+    //Get page info from config files
     public void readConfig(){
         String config = ClientConfig.PAGES.get();
         List<String> configSplit;
@@ -65,14 +66,14 @@ public class TMKPageHandler {
         configSplit = Arrays.asList(config.split("Page"));
 
         configSplit.forEach(page -> {
-            System.out.println("Too Many Keybinds: " + page);
+            System.out.println("Too Many Keybinds: " + page); //Remove when custom page is complete
             List<String> info = new ArrayList<>();
             info.add(StringUtils.substringBetween(page, "name=", ";"));
             info.add(StringUtils.substringBetween(page, "keys=", ";"));
             info.add(StringUtils.substringBetween(page, "page_number=", ";"));
             info.add(StringUtils.substringBetween(page, "hidden=", "}"));
             pageInfo.add(info);
-            System.out.println("Too Many Keybinds: " + pageInfo.get(configSplit.indexOf(page)));
+            System.out.println("Too Many Keybinds: " + pageInfo.get(configSplit.indexOf(page))); //Helps me understand what exactly I need to read, will remove when custom page is complete
         });
 
         pageInfo.remove(0);

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -56,6 +56,27 @@ public class TMKPageHandler {
         screen.update();
     }
 
+    public void readConfig(){
+        String config = ClientConfig.PAGES.get();
+        List<String> configSplit;
+        List<List<String>> pageInfo = new ArrayList<>();
+        configSplit = Arrays.asList(config.split("Page"));
+
+        configSplit.forEach(page -> {
+            System.out.println("Too Many Keybinds: " + page);
+            List<String> info = new ArrayList<>();
+            info.add(StringUtils.substringBetween(page, "name=", ";"));
+            info.add(StringUtils.substringBetween(page, "keys=", ";"));
+            info.add(StringUtils.substringBetween(page, "page_number=", ";"));
+            info.add(StringUtils.substringBetween(page, "hidden=", "}"));
+            pageInfo.add(info);
+            System.out.println("Too Many Keybinds: " + pageInfo.get(configSplit.indexOf(page)));
+        });
+
+        pageInfo.remove(0);
+        System.out.println(pageInfo);
+    }
+
     //Create and sort pages from Map by adding to List based on order of Categories
     public List<TMKPage> createPages(Map<String, List<KeyMapping>> catKeys, List<String> cat){
         List<TMKPage> t = new ArrayList<>();

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -5,6 +5,7 @@ import io.github.jkaano.toomanykeybinds.client.gui.PageButtonIdentity;
 import io.github.jkaano.toomanykeybinds.client.gui.TMKPage;
 import io.github.jkaano.toomanykeybinds.client.screen.TMKScreen;
 import net.minecraft.client.KeyMapping;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/TMKPageHandler.java
@@ -35,6 +35,11 @@ public class TMKPageHandler {
             pageButtons.add(pbi);
         }); //Initialize buttons
 
+        ClientConfig.PAGES.set(pageSelect.toString());
+        ClientConfig.PAGES.save();
+
+        readConfig();
+
     }
 
     public void updateSearchable(Map<String, List<KeyMapping>> map, List<String> categories, TMKScreen screen){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
@@ -1,6 +1,6 @@
 package io.github.jkaano.toomanykeybinds.client.compatibility;
 
-import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
+import io.github.jkaano.toomanykeybinds.TooManyKeybinds;
 import net.minecraftforge.fml.ModList;
 
 public class EssentialsCompatibility {

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
@@ -12,7 +12,11 @@ public class EssentialsCompatibility {
     //public static boolean essentials = true;
 
     public static void setEssentials() {
-        essentials = ModList.get().isLoaded("essential");
+        //essentials = ModList.get().isLoaded("essential");
+        //Add True/False if essentials is installed/not installed to the robot compatibility list
+        TooManyKeybinds.getRobotCompatibilityChecker().addCompatible(
+                ModList.get().isLoaded("essential")
+        );
 
         //If essentials is installed, turn off auto key press, or if it is uninstalled turn it on
         //Only do this if the user hasn't manually changed the key bind

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
@@ -9,24 +9,11 @@ public class EssentialsCompatibility {
     //This class just holds a variable that checks if essentials is installed and uses a less effective
     //key press method. Using robot allows for keyRelease which some keybinds check for, Forge keyDown
     //doesn't trigger these events.
-    //public static boolean essentials = true;
 
     public static void setEssentials() {
-        //essentials = ModList.get().isLoaded("essential");
-        //Add True/False if essentials is installed/not installed to the robot compatibility list
         TooManyKeybinds.getRobotCompatibilityChecker().addCompatible(
                 ModList.get().isLoaded("essential")
         );
-
-        //If essentials is installed, turn off auto key press, or if it is uninstalled turn it on
-        //Only do this if the user hasn't manually changed the key bind
-//        if(essentials && !ClientConfig.LOCK_AUTO.get()){
-//            ClientConfig.AUTOMATIC_KEY_PRESS.set(false);
-//            ClientConfig.AUTOMATIC_KEY_PRESS.save();
-//        }else if(!ClientConfig.LOCK_AUTO.get()){
-//            ClientConfig.AUTOMATIC_KEY_PRESS.set(true);
-//            ClientConfig.AUTOMATIC_KEY_PRESS.save();
-//        }
     }
 
 }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
@@ -9,7 +9,7 @@ public class EssentialsCompatibility {
     //This class just holds a variable that checks if essentials is installed and uses a less effective
     //key press method. Using robot allows for keyRelease which some keybinds check for, Forge keyDown
     //doesn't trigger these events.
-    public static boolean essentials = true;
+    //public static boolean essentials = true;
 
     public static void setEssentials() {
         essentials = ModList.get().isLoaded("essential");

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/EssentialsCompatibility.java
@@ -20,13 +20,13 @@ public class EssentialsCompatibility {
 
         //If essentials is installed, turn off auto key press, or if it is uninstalled turn it on
         //Only do this if the user hasn't manually changed the key bind
-        if(essentials && !ClientConfig.LOCK_AUTO.get()){
-            ClientConfig.AUTOMATIC_KEY_PRESS.set(false);
-            ClientConfig.AUTOMATIC_KEY_PRESS.save();
-        }else if(!ClientConfig.LOCK_AUTO.get()){
-            ClientConfig.AUTOMATIC_KEY_PRESS.set(true);
-            ClientConfig.AUTOMATIC_KEY_PRESS.save();
-        }
+//        if(essentials && !ClientConfig.LOCK_AUTO.get()){
+//            ClientConfig.AUTOMATIC_KEY_PRESS.set(false);
+//            ClientConfig.AUTOMATIC_KEY_PRESS.save();
+//        }else if(!ClientConfig.LOCK_AUTO.get()){
+//            ClientConfig.AUTOMATIC_KEY_PRESS.set(true);
+//            ClientConfig.AUTOMATIC_KEY_PRESS.save();
+//        }
     }
 
 }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/RobotCompatibilityChecker.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/RobotCompatibilityChecker.java
@@ -12,7 +12,7 @@ public class RobotCompatibilityChecker{
     private ArrayList<Boolean> isCompatible;
 
     public RobotCompatibilityChecker(){
-        isCompatible = new ArrayList<Boolean>();
+        isCompatible = new ArrayList<>();
     }
 
     public void addCompatible(boolean RobotCompatibility){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/RobotCompatibilityChecker.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/compatibility/RobotCompatibilityChecker.java
@@ -1,0 +1,26 @@
+package io.github.jkaano.toomanykeybinds.client.compatibility;
+
+import java.util.ArrayList;
+
+public class RobotCompatibilityChecker{
+
+    /*
+     *To allow for easy compatibility patches, this ArrayList will be written to by ModCompatibility files.
+     * Check EssentialsCompatibility for reference.
+     * The main purpose is to combat Robot compatibility issues, if any value is true it will skip the robot.
+     */
+    private ArrayList<Boolean> isCompatible;
+
+    public RobotCompatibilityChecker(){
+        isCompatible = new ArrayList<Boolean>();
+    }
+
+    public void addCompatible(boolean RobotCompatibility){
+        isCompatible.add(RobotCompatibility);
+    }
+
+    public boolean checkRobotCompatibility(){
+        return !isCompatible.contains(true);
+    }
+
+}

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
@@ -19,7 +19,7 @@ public class ClientConfig {
 
         AUTOMATIC_KEY_PRESS = BUILDER.comment("Automatic Key Press").define("auto_key_press", true);
         LOCK_AUTO = BUILDER.define("lock_value_on_startup", false);
-        PAGES = BUILDER.comment("Pages").define("pages", "");
+        PAGES = BUILDER.comment("Pages - DO NOT TOUCH - INCOMPLETE").define("pages", ""); //Remember to change page comment if you fix this
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
@@ -11,6 +11,8 @@ public class ClientConfig {
     public static ForgeConfigSpec.ConfigValue<Boolean> AUTOMATIC_KEY_PRESS;
     public static ForgeConfigSpec.ConfigValue<Boolean> LOCK_AUTO;
 
+    public static ForgeConfigSpec.ConfigValue<String> PAGES;
+
     static {
 
         BUILDER.push("Too Many Keybinds Configuration");

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/config/ClientConfig.java
@@ -19,6 +19,7 @@ public class ClientConfig {
 
         AUTOMATIC_KEY_PRESS = BUILDER.comment("Automatic Key Press").define("auto_key_press", true);
         LOCK_AUTO = BUILDER.define("lock_value_on_startup", false);
+        PAGES = BUILDER.comment("Pages").define("pages", "");
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
@@ -3,7 +3,6 @@ package io.github.jkaano.toomanykeybinds.client.gui;
 import com.mojang.blaze3d.platform.InputConstants;
 import io.github.jkaano.toomanykeybinds.TooManyKeybinds;
 import io.github.jkaano.toomanykeybinds.client.Keybindings;
-import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
 import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import io.github.jkaano.toomanykeybinds.client.handler.RobotHandler;
 import net.minecraft.client.KeyMapping;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
@@ -89,7 +89,7 @@ public class ButtonIdentity{
         timer.schedule(new TimerTask() {
             @Override
             public void run() {
-                if(!EssentialsCompatibility.essentials){
+                if(RobotHandler.usingRobot()){
                     RobotHandler.simulateKeyPress(key);
                 }else{
                     key.setDown(true);

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
@@ -102,7 +102,7 @@ public class ButtonIdentity{
             @Override
             public void run() {
                 KeyMapping.set(Keybindings.INSTANCE.keySetter.getKey(), false);
-                if(!EssentialsCompatibility.essentials){
+                if(RobotHandler.usingRobot()){
                     RobotHandler.simulateKeyRelease(key);
                 }else{
                     key.setDown(false);

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/ButtonIdentity.java
@@ -82,6 +82,7 @@ public class ButtonIdentity{
     private void changeKey(InputConstants.Key toKey, KeyModifier mod){
         key.setKeyModifierAndCode(mod, toKey);
         KeyMapping.resetMapping();
+        KeyMapping.resetToggleKeys();
     }
 
     private void pressKey(KeyMapping key){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/TMKPage.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/gui/TMKPage.java
@@ -11,18 +11,26 @@ public class TMKPage {
     private final String name;
 
     private final List<KeyMapping> keys;
+    private final List<String> keyNames = new ArrayList<>();
     private List<ButtonIdentity> buttonIdentities;
+
+    private boolean hidden = false;
 
     public TMKPage(String name, int page_number, List<KeyMapping> keys){
         this.name = name;
         this.page_number = page_number;
         this.keys = keys;
+        keys.forEach(key -> {this.keyNames.add(key.getName());});
         initButtons();
     }
 
     public void initButtons(){
         buttonIdentities = new ArrayList<>();
         keys.forEach(key -> {buttonIdentities.add(new ButtonIdentity(key));});
+    }
+
+    public void setHidden(boolean value){
+        this.hidden = value;
     }
 
     //Getters
@@ -40,7 +48,7 @@ public class TMKPage {
 
     @Override
     public String toString(){
-        return "Page{name='" + name + "', keys='" + keys + ", page number='" + page_number + "'}";
+        return "Page{name=" + name + ";keys=" + keyNames + ";page_number=" + page_number + ";hidden=" + hidden + "}";
     }
 
 }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
@@ -3,7 +3,6 @@ package io.github.jkaano.toomanykeybinds.client.handler;
 import io.github.jkaano.toomanykeybinds.TooManyKeybinds;
 import io.github.jkaano.toomanykeybinds.client.Keybindings;
 import io.github.jkaano.toomanykeybinds.client.KeyHandler;
-import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -21,8 +20,6 @@ public class ClientModHandler {
         System.out.println("Too Many Keybinds: Creating keybind list");
         TooManyKeybinds.tmkHandler = new KeyHandler();
         System.out.println("Too Many Keybinds: Successfully created keybind list");
-
-        EssentialsCompatibility.setEssentials();
 
     }
 

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
@@ -3,6 +3,7 @@ package io.github.jkaano.toomanykeybinds.client.handler;
 import io.github.jkaano.toomanykeybinds.TooManyKeybinds;
 import io.github.jkaano.toomanykeybinds.client.Keybindings;
 import io.github.jkaano.toomanykeybinds.client.KeyHandler;
+import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -14,6 +15,9 @@ public class ClientModHandler {
 
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event){
+
+        //Set compatibilities
+        EssentialsCompatibility.setEssentials();
 
         RobotHandler.setCompatConfig();
 

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
@@ -16,6 +16,8 @@ public class ClientModHandler {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent event){
 
+        RobotHandler.setCompatConfig();
+
         System.out.println("Too Many Keybinds: Creating keybind list");
         TooManyKeybinds.tmkHandler = new KeyHandler();
         System.out.println("Too Many Keybinds: Successfully created keybind list");

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/ClientModHandler.java
@@ -19,7 +19,8 @@ public class ClientModHandler {
         //Set compatibilities
         EssentialsCompatibility.setEssentials();
 
-        RobotHandler.setCompatConfig();
+        //Create an initial configuration support for the KeyHandler to use as it defines some variables
+        RobotHandler.setCompatConfig(); //Maybe move key press handling to a new class so I don't have to initialize and then reset later?
 
         System.out.println("Too Many Keybinds: Creating keybind list");
         TooManyKeybinds.tmkHandler = new KeyHandler();

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -43,4 +43,22 @@ public class RobotHandler {
         robot.keyRelease(keyMapping.getKey().getValue());
     }
 
+    public static void setCompatConfig(){
+        if(!useRobot && !ClientConfig.LOCK_AUTO.get()){
+            ClientConfig.AUTOMATIC_KEY_PRESS.set(false);
+            ClientConfig.AUTOMATIC_KEY_PRESS.save();
+        }else if(!ClientConfig.LOCK_AUTO.get()){
+            ClientConfig.AUTOMATIC_KEY_PRESS.set(true);
+            ClientConfig.AUTOMATIC_KEY_PRESS.save();
+        }
+    }
+
+    public static void checkCompatibility(){
+        useRobot = robotCompatibilityChecker.checkRobotCompatibility();
+    }
+
+    public static boolean usingRobot(){
+        return useRobot;
+    }
+
 }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -17,10 +17,8 @@ public class RobotHandler {
 
     @SubscribeEvent
     public static void loadRobot(FMLLoadCompleteEvent event){
-        if(!EssentialsCompatibility.essentials) {
-            System.out.println("Too Many Keybinds: Essentials not found, Load Robot");
-            System.setProperty("java.awt.headless", "false");
-            System.out.println("Too Many Keybinds: headless: " + System.getProperty("java.awt.headless"));
+        robotCompatibilityChecker = TooManyKeybinds.getRobotCompatibilityChecker();
+        checkCompatibility();
 
         if(useRobot) {
             try {

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -14,6 +14,8 @@ import java.awt.*;
 public class RobotHandler {
 
     private static Robot robot;
+    private static boolean useRobot;
+    private static RobotCompatibilityChecker robotCompatibilityChecker;
 
     @SubscribeEvent
     public static void loadRobot(FMLLoadCompleteEvent event){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -31,7 +31,6 @@ public class RobotHandler {
                 System.out.println("Assigning new robot");
                 robot = new Robot();
             } catch (AWTException e) {
-                //throw new RuntimeException("Too Many Keybinds: Robot does not work");
                 e.printStackTrace();
                 useRobot = false;
             }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -26,7 +26,9 @@ public class RobotHandler {
                 System.out.println("Assigning new robot");
                 robot = new Robot();
             } catch (AWTException e) {
-                throw new RuntimeException(e);
+                //throw new RuntimeException("Too Many Keybinds: Robot does not work");
+                e.printStackTrace();
+                useRobot = false;
             }
         }else{
             System.out.println("Too Many Keybinds: Conflict Found, ignoring robot");

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -1,7 +1,8 @@
 package io.github.jkaano.toomanykeybinds.client.handler;
 
 import io.github.jkaano.toomanykeybinds.TooManyKeybinds;
-import io.github.jkaano.toomanykeybinds.client.compatibility.EssentialsCompatibility;
+import io.github.jkaano.toomanykeybinds.client.compatibility.RobotCompatibilityChecker;
+import io.github.jkaano.toomanykeybinds.client.config.ClientConfig;
 import net.minecraft.client.KeyMapping;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.SubscribeEvent;

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -43,7 +43,6 @@ public class RobotHandler {
 
     public static void simulateKeyPress(KeyMapping keyMapping){
         robot.keyPress(keyMapping.getKey().getValue());
-
     }
 
     public static void simulateKeyRelease(KeyMapping keyMapping){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -39,6 +39,9 @@ public class RobotHandler {
             System.out.println("Too Many Keybinds: Conflict Found, ignoring robot");
         }
 
+        //Reset the compatibility config AFTER checking if robot is in use.
+        setCompatConfig();
+
     }
 
     public static void simulateKeyPress(KeyMapping keyMapping){

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -29,7 +29,7 @@ public class RobotHandler {
                 throw new RuntimeException(e);
             }
         }else{
-            System.out.println("Essentials found, not using robot");
+            System.out.println("Too Many Keybinds: Conflict Found, ignoring robot");
         }
 
     }

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -22,6 +22,7 @@ public class RobotHandler {
             System.setProperty("java.awt.headless", "false");
             System.out.println("Too Many Keybinds: headless: " + System.getProperty("java.awt.headless"));
 
+        if(useRobot) {
             try {
                 System.out.println("Too Many Keybinds: Essentials not found, Load Robot");
                 System.setProperty("java.awt.headless", "false");

--- a/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
+++ b/src/main/java/io/github/jkaano/toomanykeybinds/client/handler/RobotHandler.java
@@ -23,6 +23,9 @@ public class RobotHandler {
             System.out.println("Too Many Keybinds: headless: " + System.getProperty("java.awt.headless"));
 
             try {
+                System.out.println("Too Many Keybinds: Essentials not found, Load Robot");
+                System.setProperty("java.awt.headless", "false");
+                System.out.println("Too Many Keybinds: headless: " + System.getProperty("java.awt.headless"));
                 System.out.println("Assigning new robot");
                 robot = new Robot();
             } catch (AWTException e) {


### PR DESCRIPTION
Adds some framework for custom pages but most importantly it adds a broader compatibility patch for mods. Previously the mod would only check if a specific mod was installed and if it was, disable the java robot but now it just checks if it can change to a headless environment, if it can't it doesn't use the robot. This should encompass much more and hopefully reduce problems in large modpacks.